### PR TITLE
Track property changes on fake instances when using Moq Engine (issue #6...

### DIFF
--- a/Source/Machine.Fakes.Adapters.Moq/MoqFakeEngine.cs
+++ b/Source/Machine.Fakes.Adapters.Moq/MoqFakeEngine.cs
@@ -20,6 +20,8 @@ namespace Machine.Fakes.Adapters.Moq
             var closedMockType = typeof(Mock<>).MakeGenericType(interfaceType);
             var instance = (args != null && args.Length > 0) ? Activator.CreateInstance(closedMockType, args) : Activator.CreateInstance(closedMockType);
             var objectProperty = closedMockType.GetProperty("Object", closedMockType);
+            var setupAllProperties = closedMockType.GetMethod("SetupAllProperties");
+            setupAllProperties.Invoke(instance, null);
 
             return objectProperty.GetValue(instance, null);
         }

--- a/Source/Machine.Fakes.Adapters.Specs/Machine.Fakes.Adapters.Specs.csproj
+++ b/Source/Machine.Fakes.Adapters.Specs/Machine.Fakes.Adapters.Specs.csproj
@@ -89,6 +89,7 @@
     <Compile Include="RhinoMocks\InlineConstraints.cs" />
     <Compile Include="RhinoMocks\MethodCallOccuranceSpecs.cs" />
     <Compile Include="RhinoMocks\QueryOptionsSpecs.cs" />
+    <Compile Include="SampleCode\ClassWithProperties.cs" />
     <Compile Include="SampleCode\ClassWithUnfakableParameter.cs" />
     <Compile Include="SampleCode\DummyNoDefaultCtorClass.cs" />
     <Compile Include="SampleCode\IFlashVerifier.cs" />

--- a/Source/Machine.Fakes.Adapters.Specs/Moq/EngineSpecs.cs
+++ b/Source/Machine.Fakes.Adapters.Specs/Moq/EngineSpecs.cs
@@ -91,4 +91,20 @@ namespace Machine.Fakes.Adapters.Specs.Moq
             result.ShouldEqual("Faked result");
         };
     }
+
+    [Subject(typeof(MoqFakeEngine))]
+    [Tags("Moq", "Setup all properties")]
+    public class Setup_all_properties_on_each_fake : WithCurrentEngine<MoqFakeEngine>
+    {
+        It should_track_property_changes = () =>
+            _fake.VirtualProperty.ShouldEqual("new property value");
+
+        Because of = () =>
+            _fake.VirtualProperty = "new property value";
+
+        Establish context = () =>
+            _fake = FakeEngineGateway.Fake<ClassWithProperties>();
+
+        static ClassWithProperties _fake;
+    }
 }

--- a/Source/Machine.Fakes.Adapters.Specs/SampleCode/ClassWithProperties.cs
+++ b/Source/Machine.Fakes.Adapters.Specs/SampleCode/ClassWithProperties.cs
@@ -1,0 +1,7 @@
+﻿namespace Machine.Fakes.Adapters.Specs.SampleCode
+{
+    public class ClassWithProperties
+    {
+        public virtual string VirtualProperty { get; set; }
+    }
+}


### PR DESCRIPTION
...)

I haven't implemented it on PartialMock<T> since I wasn't sure exactly
when that was used.
