### PR TITLE
Added RhinoMocksDefault Property Behavior for all Properties on a create...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Source/GlobalAssemblyInfo.cs
 *_mm_cache.bin
 *.user
 Source/packages
+*.ncrunch*

--- a/Source/Machine.Fakes.Adapters.Rhinomocks/Machine.Fakes.Adapters.Rhinomocks.csproj
+++ b/Source/Machine.Fakes.Adapters.Rhinomocks/Machine.Fakes.Adapters.Rhinomocks.csproj
@@ -52,6 +52,7 @@
     <Compile Include="RhinoCommandOptions.cs" />
     <Compile Include="RhinoFakeEngine.cs" />
     <Compile Include="RhinoMethodCallOccurance.cs" />
+    <Compile Include="RhinoPropertyBehavior.cs" />
     <Compile Include="RhinoQueryOptions.cs" />
     <Compile Include="WithFakes.cs" />
     <Compile Include="WithSubject.cs" />

--- a/Source/Machine.Fakes.Adapters.Rhinomocks/RhinoPropertyBehavior.cs
+++ b/Source/Machine.Fakes.Adapters.Rhinomocks/RhinoPropertyBehavior.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Rhino.Mocks;
+using Rhino.Mocks.Interfaces;
+
+
+// Based on implementation used in Rhino Mocks original Stubs creation
+
+namespace Machine.Fakes.Adapters.Rhinomocks
+{
+    internal static class RhinoPropertyBehavior
+    {
+        static bool CanWriteToPropertyThroughPublicSignature(PropertyInfo property)
+        {
+            if (property.CanWrite)
+                return property.GetSetMethod(false) != null;
+            return false;
+        }
+
+        static void CreateDefaultValueForValueTypeProperty(IMockedObject mockedObject, PropertyInfo property)
+        {
+            mockedObject.HandleProperty(property.GetSetMethod(true), new[]
+                {
+                    Activator.CreateInstance(property.PropertyType)
+                });
+        }
+
+        static void SetPropertyBehavior(IMockedObject mockedObject, Type[] implementedTypes)
+        {
+            foreach (Type type in implementedTypes)
+            {
+                if (type.BaseType != null && type.BaseType != typeof (object))
+                    SetPropertyBehavior(mockedObject, new[] {type.BaseType});
+
+                SetPropertyBehavior(mockedObject, type.GetInterfaces());
+                foreach (PropertyInfo propertyInfo in type.GetProperties())
+                {
+                    if (propertyInfo.CanRead && CanWriteToPropertyThroughPublicSignature(propertyInfo))
+                    {
+                        if (!mockedObject.RegisterPropertyBehaviorFor(propertyInfo) &&
+                            propertyInfo.PropertyType.IsValueType)
+                        {
+                            CreateDefaultValueForValueTypeProperty(mockedObject, propertyInfo);
+                        }
+                    }
+                }
+            }
+        }
+
+        public static void RegisterPropertyBehavior(IMockedObject mockedObject)
+        {
+            SetPropertyBehavior(mockedObject, mockedObject.ImplementedTypes);
+        }
+
+        public static void RemovePropertiesBehavior(object fake)
+        {
+            var mockedObject = fake as IMockedObject;
+            if (mockedObject != null)
+                mockedObject.ClearState(BackToRecordOptions.PropertyBehavior);
+        }
+    }
+}

--- a/Source/Machine.Fakes.Adapters.Specs/Machine.Fakes.Adapters.Specs.csproj
+++ b/Source/Machine.Fakes.Adapters.Specs/Machine.Fakes.Adapters.Specs.csproj
@@ -92,6 +92,7 @@
     <Compile Include="RhinoMocks\EngineSpecs.cs" />
     <Compile Include="RhinoMocks\InlineConstraints.cs" />
     <Compile Include="RhinoMocks\MethodCallOccuranceSpecs.cs" />
+    <Compile Include="RhinoMocks\PropertyBehaviorSpecs.cs" />
     <Compile Include="RhinoMocks\QueryOptionsSpecs.cs" />
     <Compile Include="SampleCode\ITypeWithProperty.cs" />
     <Compile Include="SampleCode\ClassWithUnfakableParameter.cs" />

--- a/Source/Machine.Fakes.Adapters.Specs/RhinoMocks/PropertyBehaviorSpecs.cs
+++ b/Source/Machine.Fakes.Adapters.Specs/RhinoMocks/PropertyBehaviorSpecs.cs
@@ -1,0 +1,60 @@
+﻿using Machine.Fakes.Adapters.Rhinomocks;
+using Machine.Fakes.Internal;
+using Machine.Specifications;
+
+namespace Machine.Fakes.Adapters.Specs.RhinoMocks
+{
+    public interface IProperties
+    {
+        int Prop { get; set; }
+        bool TheFunction();
+    }
+
+    [Subject(typeof(RhinoFakeEngine))]
+    [Tags("Properties", "Rhinomocks")]
+    public class When_setting_a_simple_property_to_value_2 : WithCurrentEngine<RhinoFakeEngine>
+    {
+        Establish context = () => _fake = FakeEngineGateway.Fake<IProperties>();
+
+        Because of = () => _fake.Prop = 2;
+
+        It should_has_value_2 = () => _fake.Prop.ShouldEqual(2);
+        static IProperties _fake;
+    }
+
+
+    [Subject(typeof(RhinoFakeEngine))]
+    [Tags("Properties", "Rhinomocks")]
+    public class When_setting_an_behavior_on_a_function_it_should_not_remove_property_behavior : WithCurrentEngine<RhinoFakeEngine>
+    {
+        Establish context = () =>
+        {
+            _fake = FakeEngineGateway.Fake<IProperties>();
+        };
+
+        Because of = () =>
+        {
+            _fake.WhenToldTo(f => f.TheFunction()).Return(true);
+            _fake.Prop = 3;
+        };
+
+        It should_the_property_value_is_still_3 = () => _fake.Prop.ShouldEqual(3);
+        static IProperties _fake;
+    }
+
+    [Subject(typeof(RhinoFakeEngine))]
+    [Tags("Properties", "Rhinomocks")]
+    public class When_setting_a_simple_property_to_value_2_and_then_to_3 : WithCurrentEngine<RhinoFakeEngine>
+    {
+        Establish context = () => _fake = FakeEngineGateway.Fake<IProperties>();
+
+        Because of = () =>
+        {
+            _fake.Prop = 2;
+            _fake.Prop = 3;
+        };
+
+        It should_has_value_3 = () => _fake.Prop.ShouldEqual(3);
+        static IProperties _fake;
+    }
+}


### PR DESCRIPTION
Added RhinoMocksDefault Property Behavior for all Properties on a created fake. So that per default all properties can directly use like with the other MockingFrameworks.

But if you set an expectation on an property (.WhenToldTo()) the Property Behavior will be removed from all properties on the created object. This is for backward compatibility, also needed if you need more complex Behavior setup. (see Issue 44)
