### PR TITLE
Fixed WithFakes to work correctly under Gallio test runner

### DIFF
--- a/Source/Machine.Fakes/WithFakes.cs
+++ b/Source/Machine.Fakes/WithFakes.cs
@@ -25,6 +25,11 @@ namespace Machine.Fakes
         /// </summary>
         protected static SpecificationController<TSubject, TFakeEngine> _specificationController;
 
+        Establish context = () =>
+        {
+            _specificationController = new SpecificationController<TSubject, TFakeEngine>();
+        };
+
         /// <summary>
         ///   Creates a fake of the type specified by <typeparamref name = "TInterfaceType" />.
         /// </summary>
@@ -238,12 +243,5 @@ namespace Machine.Fakes
     /// </typeparam>
     public abstract class WithFakes<TFakeEngine> : WithFakes<object, TFakeEngine> where TFakeEngine : IFakeEngine, new()
     {
-        /// <summary>
-        /// Creates a new instance of the <see cref="WithFakes{TFakeEngine}"/> class.
-        /// </summary>
-        protected WithFakes()
-        {
-            _specificationController = new SpecificationController<object, TFakeEngine>();
-        }
     }
 }

--- a/Source/Machine.Fakes/WithSubject.cs
+++ b/Source/Machine.Fakes/WithSubject.cs
@@ -25,8 +25,6 @@ namespace Machine.Fakes
         /// </summary>
         protected WithSubject()
         {
-            _specificationController = new SpecificationController<TSubject, TFakeEngine>();
-
             ContextFactory.ChangeAllowedNumberOfBecauseBlocksTo(2);
         }
 


### PR DESCRIPTION
Fixed WithFakes to work correctly under Gallio test runner that creates all the test classes before running any tests
- Moved init of a SpecificationController static field from instance constructor into Setup
- all the specs of machine.fakes itself now pass under Gallio runner as well
